### PR TITLE
[Nuvoton M4xx FLASH 코드 업데이트]

### DIFF
--- a/inc/targets/nuvoton/class_flash.h
+++ b/inc/targets/nuvoton/class_flash.h
@@ -22,12 +22,16 @@ public :
 
 	error_t program(uint16_t page, uint32_t *src, uint32_t count) __attribute__((optimize("-O1")));
 	
+	error_t read4Xbytes(uint16_t page, uint16_t sector, uint16_t count, uint32_t *dataReg);				//page : 페이지 , sector : 페이지 내 위치(4byte 단위), count : 읽어올 바이트 수 (1 입력 시 4바이트 리드), dataReg : 읽은 데이터 기록할 주소 
+	
 private :
 	error_t executeCommand(uint8_t cmd) __attribute__((optimize("-O1")));
 
 	error_t enable(bool en) __attribute__((optimize("-O1")));
 
 	error_t program32bit(uint32_t addr, uint32_t data) __attribute__((optimize("-O1")));
+
+	error_t read32bit(uint32_t addr, uint32_t* data) __attribute__((optimize("-O1")));
 };
 
 #endif

--- a/inc/targets/nuvoton/fmc_reg.h
+++ b/inc/targets/nuvoton/fmc_reg.h
@@ -56,7 +56,8 @@
 #define FMC_ISPCMD_CMD_Pos               (0)                                               /*!< FMC_T::ISPCMD: CMD Position            */
 #define FMC_ISPCMD_CMD_Msk               (0x7ful << FMC_ISPCMD_CMD_Pos)                    /*!< FMC_T::ISPCMD: CMD Mask                */
 
-#define FMC_ISPCMD_FLASH_READ					(0x01)
+#define FMC_ISPCMD_FLASH_READ					(0x00)
+#define FMC_ISPCME_FLASH_READ_64BIT				(0x40)
 #define FMC_ISPCMD_READ_UNIQUE_ID				(0x04)
 #define FMC_ISPCMD_READ_FLASH_ALL_ONE_READ		(0x08)
 #define FMC_ISPCMD_READ_COMPANY_ID				(0x0B)

--- a/src/targets/nuvoton/driver/drv_flash_nuvoton.cpp
+++ b/src/targets/nuvoton/driver/drv_flash_nuvoton.cpp
@@ -65,6 +65,22 @@ error_t Flash::program(uint16_t page, uint32_t *src, uint32_t count)
 	return error_t::ERROR_NONE;
 }
 
+error_t Flash::read4Xbytes(uint16_t page, uint16_t sector, uint16_t count, uint32_t *dataReg)  //최대 4Kb 읽기, 1섹터당 4byte, 1카운트 당 4byte, dataReg 크기는 4byte당 1
+{
+	uint32_t addr = getPageAddress(page) + sector;
+	error_t result;
+
+	for(uint16_t i = 0; i < count; i++)
+	{
+		result = read32bit(addr,dataReg++);
+		if(result != error_t::ERROR_NONE)
+			return result;
+		addr = addr + 4;
+	}
+
+	return result;
+}
+
 uint32_t Flash::getPageAddress(uint16_t page)
 {
 	return (uint32_t)page * 4096;
@@ -89,6 +105,22 @@ error_t Flash::program32bit(uint32_t addr, uint32_t data)
 		return error_t::FAILED_FLASH_PROGRAM;
 	else
 		return result;
+}
+
+error_t Flash::read32bit(uint32_t addr, uint32_t* data)
+{
+	error_t result;
+
+	enable(true);
+
+	FMC->ISPADDR = addr;
+	
+	result = executeCommand(FMC_ISPCMD_FLASH_READ);
+
+	if(result == error_t::ERROR_NONE)
+		data[0] = FMC->ISPDAT;
+	
+	return result;	
 }
 
 error_t Flash::executeCommand(uint8_t cmd)


### PR DESCRIPTION
 - 내부 플래시 4바이트 읽기 추가
 - FMC-ISPCMD 읽기 값 오류 수정